### PR TITLE
EMP-15180 - Update sample app to support chromecast playback with no subtitles

### DIFF
--- a/SDKSampleApp/ViewControllers/TrackSelectionViewController.swift
+++ b/SDKSampleApp/ViewControllers/TrackSelectionViewController.swift
@@ -147,8 +147,9 @@ extension TrackSelectionViewController {
             let vm = text[index]
             if vm.active {
                 return IndexPath(row: index, section: 0)
+            } else {
+                return IndexPath(row: text.count, section: 0)
             }
-            return nil
             }.last
     }
 }

--- a/SDKSampleApp/ViewModel/TrackSelectionViewModel.swift
+++ b/SDKSampleApp/ViewModel/TrackSelectionViewModel.swift
@@ -15,7 +15,7 @@ class TrackSelectionViewModel: Equatable {
     }
     
     var displayName: String {
-        return model?.displayName ?? "Off"
+        return model?.displayName ?? "None"
     }
     
     public static func == (lhs: TrackSelectionViewModel, rhs: TrackSelectionViewModel) -> Bool {


### PR DESCRIPTION
When chrome cast start with , empty subtitles, select None in the subtitle list